### PR TITLE
Fixed 'Diable' typo.

### DIFF
--- a/src/disable_output_limit.hpp
+++ b/src/disable_output_limit.hpp
@@ -42,7 +42,7 @@ struct DisableOutputLimitModuleWidget : ModuleWidget {
 		DisableOutputLimitModule* dolm = dynamic_cast<DisableOutputLimitModule*>(module);
 		assert(dolm);
 		menu->addChild(new MenuLabel());
-		menu->addChild(new DisableOutputLimitMenuItem(dolm, "Diable Output Limit"));
+		menu->addChild(new DisableOutputLimitMenuItem(dolm, "Disable output limit"));
 	}
 };
 


### PR DESCRIPTION
Changed 'Diable' to 'Disable' and made only the first word start with a capital letter to match the standard menu item look.