### PR TITLE
Revive context menus for UMIX & MUMIX.

### DIFF
--- a/src/UMix.cpp
+++ b/src/UMix.cpp
@@ -12,10 +12,17 @@ int UMix::channels() {
 void UMix::processChannel(const ProcessArgs& args, int c) {
 	outputs[OUT_OUTPUT].setChannels(_channels);
 
-	if (_sum) {
-		float out = 0.0f;
-		for (int i = 0; i < 8; ++i) {
+	float out = 0.0f;
+	int active = 0;
+	for (int i = 0; i < NUM_INPUTS; i++) {
+		if (inputs[IN1_INPUT + i].isConnected()) {
 			out += _inputGainLevel * inputs[IN1_INPUT + i].getPolyVoltage(c);
+			++active;
+		}
+	}
+	if (active > 0) {
+		if (!_sum) {
+			out /= (float)active;
 		}
 		if (_clippingMode == HARD_CLIPPING) {
 			outputs[OUT_OUTPUT].setVoltage(clamp(out, -12.0f, 12.0f), c);
@@ -25,26 +32,7 @@ void UMix::processChannel(const ProcessArgs& args, int c) {
 		}
 	}
 	else {
-		float out = 0.0f;
-		int active = 0;
-		for (int i = 0; i < 8; ++i) {
-			if (inputs[IN1_INPUT + i].isConnected()) {
-				out += _inputGainLevel * inputs[IN1_INPUT + i].getPolyVoltage(c);
-				++active;
-			}
-		}
-		if (active > 0) {
-			out /= (float)active;
-			if (_clippingMode == HARD_CLIPPING) {
-				outputs[OUT_OUTPUT].setVoltage(clamp(out, -12.0f, 12.0f), c);
-			}
-			else {
-				outputs[OUT_OUTPUT].setVoltage(_saturator[c].next(out), c);
-			}
-		}
-		else {
-			outputs[OUT_OUTPUT].setVoltage(0.0f, c);
-		}
+		outputs[OUT_OUTPUT].setVoltage(0.0f, c);
 	}
 }
 

--- a/src/matrix_base.cpp
+++ b/src/matrix_base.cpp
@@ -40,6 +40,24 @@ void MatrixBaseModule::modulate() {
 	_inputGainLevel = decibelsToAmplitude(_inputGainDb);
 }
 
+void MatrixBaseModuleWidget::contextMenu(Menu* menu) {
+	auto m = dynamic_cast<MatrixBaseModule*>(module);
+	assert(m);
+
+	OptionsMenuItem* g = new OptionsMenuItem("Input gain");
+	g->addItem(OptionMenuItem("Unity", [m]() { return (int)m->_inputGainDb == 0; }, [m]() { m->_inputGainDb = 0.0f; }));
+	g->addItem(OptionMenuItem("-3db", [m]() { return (int)m->_inputGainDb == -3; }, [m]() { m->_inputGainDb = -3.0f; }));
+	g->addItem(OptionMenuItem("-6db", [m]() { return (int)m->_inputGainDb == -6; }, [m]() { m->_inputGainDb = -6.0f; }));
+	g->addItem(OptionMenuItem("-12db", [m]() { return (int)m->_inputGainDb == -12; }, [m]() { m->_inputGainDb = -12.0f; }));
+	OptionsMenuItem::addToMenu(g, menu);
+
+	OptionsMenuItem* c = new OptionsMenuItem("Output clipping");
+	c->addItem(OptionMenuItem("Soft/saturated (better for audio)", [m]() { return m->_clippingMode == MatrixBaseModule::SOFT_CLIPPING; }, [m]() { m->_clippingMode = MatrixBaseModule::SOFT_CLIPPING; }));
+	c->addItem(OptionMenuItem("Hard/clipped (better for CV)", [m]() { return m->_clippingMode == MatrixBaseModule::HARD_CLIPPING; }, [m]() { m->_clippingMode = MatrixBaseModule::HARD_CLIPPING; }));
+	OptionsMenuItem::addToMenu(c, menu);
+
+	menu->addChild(new OptionMenuItem("Average", [m]() { return !m->_sum; }, [m]() { m->_sum = !m->_sum; }));
+}
 
 void MatrixModule::configMatrixModule(int ins, int outs, int firstParamID, int firstInputID, int firstOutputID) {
 	assert(!_paramValues && !_sls && !_saturators && !_inActive);
@@ -153,19 +171,7 @@ void MatrixModuleWidget::contextMenu(Menu* menu) {
 	assert(m);
 
 	if (m->_ins > 1) {
-		OptionsMenuItem* g = new OptionsMenuItem("Input gain");
-		g->addItem(OptionMenuItem("Unity", [m]() { return (int)m->_inputGainDb == 0; }, [m]() { m->_inputGainDb = 0.0f; }));
-		g->addItem(OptionMenuItem("-3db", [m]() { return (int)m->_inputGainDb == -3; }, [m]() { m->_inputGainDb = -3.0f; }));
-		g->addItem(OptionMenuItem("-6db", [m]() { return (int)m->_inputGainDb == -6; }, [m]() { m->_inputGainDb = -6.0f; }));
-		g->addItem(OptionMenuItem("-12db", [m]() { return (int)m->_inputGainDb == -12; }, [m]() { m->_inputGainDb = -12.0f; }));
-		OptionsMenuItem::addToMenu(g, menu);
-
-		OptionsMenuItem* c = new OptionsMenuItem("Output clipping");
-		c->addItem(OptionMenuItem("Soft/saturated (better for audio)", [m]() { return m->_clippingMode == MatrixBaseModule::SOFT_CLIPPING; }, [m]() { m->_clippingMode = MatrixBaseModule::SOFT_CLIPPING; }));
-		c->addItem(OptionMenuItem("Hard/clipped (better for CV)", [m]() { return m->_clippingMode == MatrixBaseModule::HARD_CLIPPING; }, [m]() { m->_clippingMode = MatrixBaseModule::HARD_CLIPPING; }));
-		OptionsMenuItem::addToMenu(c, menu);
-
-		menu->addChild(new OptionMenuItem("Average", [m]() { return !m->_sum; }, [m]() { m->_sum = !m->_sum; }));
+		MatrixBaseModuleWidget::contextMenu(menu);
 	}
 }
 

--- a/src/matrix_base.hpp
+++ b/src/matrix_base.hpp
@@ -26,6 +26,7 @@ struct MatrixBaseModule : BGModule {
 };
 
 struct MatrixBaseModuleWidget : BGModuleWidget {
+	void contextMenu(Menu* menu) override;
 };
 
 struct MatrixModule : MatrixBaseModule {


### PR DESCRIPTION
The menus seemed to get deleted when adding SWITCH18 and MATRIX18 modules on
Oct 4, 2020 commit 51ccb8081d614c84063e7656ba8a48daefa934dd.

* matrix_base.cpp
* matrix_base.hpp
  - Revive MatrixBaseModuleWidget::contextMenu() method, i.e. move configuring
    "Input Gain", "Output Clipping" and "Average" menu options back into it
    from MatrixModuleWidget::contextMenu() and have
    MatrixModuleWidget::contextMenu() call parent if inputs > 1.
* UMix.cpp
  - Refactor processChannel() to eliminate duplicate code.

NOTE: This patch was minimally tested.  Would rather have created an issue and
      attached patch for author to consider, but GitHub doesn't provide the
      capability to add attachments to issues and recommends forking, etc.