### PR TITLE
Clarifies scale and offset use in the LFO modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ A standard LFO featuring:
   - Reset (hard sync) input.
   - Slow mode.
 
-LFO tracks pitch CVs at the V/OCT input seven octaves lower than a normal oscillator: with a 0V input, the output frequency is note C-3 (2.04HZ).  The frequency knob is calibrated in linear volts (the small ticks), and its value is added to the input V/OCT.  With no input, the frequency range is from approximately 0.1 to 400HZ; with CV the frequency may be driven up to 2000HZ or down to arbitrarily low values.  In slow mode, the output frequency tracks the controls four octaves lower than otherwise (11 octaves below a normal oscillator).
+LFO tracks pitch CVs at the V/OCT input seven octaves lower than a normal oscillator: with a 0V input, the output frequency is note C-3 (2.04HZ).  The frequency knob is calibrated in linear volts (the small ticks), and its value is added to the input V/OCT.  With no input, the frequency range is from approximately 0.1 to 400HZ; with CV the frequency may be driven up to 2000HZ or down to arbitrarily low values.  In slow mode, the output frequency tracks the controls four octaves lower than otherwise (11 octaves below a normal oscillator). Output is `(lfo * scale / 100) + offset`.
 
 _Polyphony:_ <a href="#polyphony">Polyphonic</a>, with channels defined by the V/OCT input.
 


### PR DESCRIPTION
I have realised that the OFFSET module first sums the offset and then multiplies by the scale, as is written clearly in the OFFSET documentation.

But for the LLFO module, scale is a scale _percentage_ and, it is applied _before_ the offset, not after. I presume that the other LFO modules do the same, but it's not written in the documentation. Perhaps it is obvious, and it is a problem for me just because I'm a newbie? 

Thanks for all the amazing work!