### PR TITLE
Fix VCF's v/oct

### DIFF
--- a/src/VCF.cpp
+++ b/src/VCF.cpp
@@ -159,7 +159,8 @@ void VCF::modulateChannel(int c) {
 	f *= maxFrequency;
 	if (inputs[PITCH_INPUT].isConnected()) {
 		float pitch = clamp(inputs[PITCH_INPUT].getPolyVoltage(c), -5.0f, 5.0f);
-		f += cvToFrequency(pitch);
+		float fcv = frequencyToCV(std::max(minFrequency, f));
+		f = cvToFrequency(pitch + fcv);
 	}
 	if (inputs[FM_INPUT].isConnected()) {
 		float fm = inputs[FM_INPUT].getPolyVoltage(c);


### PR DESCRIPTION
V/oct is currently an exponential offset, but applied linearly, from a bipolar input, which is out of line with how VCV modules conventionally handle v/oct and just generally doesn't make sense or sound good. To be correct the input signal should be added in the voltage domain like the FM input.